### PR TITLE
feat: add crossing NPC spawn flow

### DIFF
--- a/scenes/app/Game.gd
+++ b/scenes/app/Game.gd
@@ -1,6 +1,7 @@
 extends Node2D
 
 const ASSIGNMENTS_TO_WIN := 5
+const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/CrossingNpc.tscn")
 
 var completed_assignments := 0 
 var level_completed := false
@@ -8,8 +9,8 @@ var level_completed := false
 @onready var world: Node2D  = $World
 @onready var player: Node = world.get_player()
 @onready var crowd_container: CrowdManager = world.get_crowd()
-@onready var street: Area2D = world.get_street()
-@onready var car: CharacterBody2D = world.get_car()
+@onready var street = world.get_street()
+@onready var car: Node2D = world.get_car()
 
 var stores: Array = []
 
@@ -40,16 +41,17 @@ func generate_assignment() -> void:
 	var store = available_stores.pick_random()
 	player.set_goal(store.color)
 
-func on_assignment_completed() -> void:
+func on_assignment_completed(_completed_store: Area2D) -> void:
 	if level_completed:
 		return
 
 	completed_assignments += 1
+	call_deferred("spawn_crossing_npc")
 
 	if completed_assignments >= ASSIGNMENTS_TO_WIN:
 		end_level()
 	else:
-		crowd_container.spawn_npc()
+		crowd_container.call_deferred("spawn_npc")
 		generate_assignment()
 
 func end_level() -> void:
@@ -67,7 +69,7 @@ func init_stores():
 	stores = get_tree().get_nodes_in_group("stores")
 	for store in stores:
 		store.unblock_store()
-		store.player_entered.connect(on_assignment_completed)
+		store.player_entered.connect(func() -> void: on_assignment_completed(store))
 	assert(stores.size() > 0)
 
 func init_npcs():
@@ -82,5 +84,24 @@ func init_npcs():
 func init_car() -> void:
 	if not car:
 		return
-	if car.has_method("spawn_car"):
-		car.call("spawn_car", street)
+	car.spawn_car(street)
+
+func spawn_crossing_npc() -> void:
+	if not world:
+		return
+
+	var pair: Array = world.get_random_store_pair()
+	if pair.size() < 2:
+		return
+
+	var from_store: Node2D = pair[0]
+	var to_store: Node2D = pair[1]
+	if randf() < 0.5:
+		var tmp: Node2D = from_store
+		from_store = to_store
+		to_store = tmp
+
+	var npc: CrossingNpc = CROSSING_NPC_SCN.instantiate() as CrossingNpc
+	world.get_entities_root().add_child(npc)
+	npc.z_index = 3
+	npc.spawn_from_stores(from_store, to_store)

--- a/scenes/app/World.gd
+++ b/scenes/app/World.gd
@@ -1,4 +1,5 @@
 extends Node2D
+class_name World
 
 @onready var player = $Entities/Player
 @onready var stores_container = $Entities/Stores
@@ -6,6 +7,35 @@ extends Node2D
 @onready var crowd = $Entities/Crowd
 @onready var street = $Environment/Street
 @onready var entities_root = $Entities
+
+const STORE_ROW_PAIRS: Array[Array] = [
+	[0, 5],
+	[1, 6],
+	[2, 7],
+	[3, 8],
+	[4, 9],
+]
+var store_pair_map: Dictionary = {}
+var stores_by_id: Dictionary = {}
+
+func _ready() -> void:
+	_build_store_pair_map()
+	_cache_stores()
+
+func _build_store_pair_map() -> void:
+	for pair in STORE_ROW_PAIRS:
+		if pair.size() < 2:
+			continue
+		
+		var a: int = pair[0]
+		var b: int = pair[1]
+		
+		store_pair_map[a] = b
+		store_pair_map[b] = a
+		
+func _cache_stores() -> void:
+	for store in get_tree().get_nodes_in_group("stores"):
+		stores_by_id[store.store_id] = store
 
 func get_player():
 	return player
@@ -24,3 +54,30 @@ func get_street():
 
 func get_entities_root():
 	return entities_root
+
+func get_paired_store(store_id: int) -> Area2D:
+	var paired_id = store_pair_map.get(store_id)
+	if paired_id == null:
+		return null
+	
+	return stores_by_id.get(paired_id)
+
+func get_store_pairs_by_row() -> Array[Array]:
+	var pairs: Array[Array] = []
+	
+	for pair_ids in STORE_ROW_PAIRS:
+		if pair_ids.size() < 2:
+			continue
+		
+		var left = stores_by_id.get(pair_ids[0])
+		var right = stores_by_id.get(pair_ids[1])
+		
+		if left and right:
+			pairs.append([left, right])
+	return pairs
+
+func get_random_store_pair() -> Array:
+	var pairs: Array[Array] = get_store_pairs_by_row()
+	if pairs.is_empty():
+		return []
+	return pairs.pick_random()

--- a/scenes/entities/crossing/CrossingNpc.gd
+++ b/scenes/entities/crossing/CrossingNpc.gd
@@ -1,0 +1,45 @@
+extends CharacterBody2D
+class_name CrossingNpc
+
+signal crossing_started(row_y: float)
+signal crossing_ended(row_y: float)
+
+@export var speed: float = 180.0
+
+var target_x: float = 0.0
+var row_y: float = 0.0
+var _active: bool = false
+
+func _ready() -> void:
+	add_to_group("crossing_npcs")
+
+func is_crossing_active() -> bool:
+	return _active
+
+func spawn_from_stores(left_store: Node2D, right_store: Node2D) -> void:
+	if not is_in_group("crossing_npcs"):
+		add_to_group("crossing_npcs")
+	row_y = left_store.global_position.y
+	global_position = Vector2(left_store.global_position.x, row_y)
+	target_x = right_store.global_position.x
+
+	var dir_x: float = sign(target_x - global_position.x)
+	if dir_x == 0.0:
+		dir_x = 1.0
+	_active = true
+	emit_signal("crossing_started", row_y)
+
+func _physics_process(_delta: float) -> void:
+	if not _active:
+		return
+
+	global_position.y = row_y
+
+	var dir_x: float = sign(target_x - global_position.x)
+	velocity = Vector2(dir_x * speed, 0.0)
+	move_and_slide()
+
+	var reached: bool = (global_position.x >= target_x) if dir_x > 0.0 else (global_position.x <= target_x)
+	if reached:
+		emit_signal("crossing_ended", row_y)
+		queue_free()

--- a/scenes/entities/crossing/CrossingNpc.gd.uid
+++ b/scenes/entities/crossing/CrossingNpc.gd.uid
@@ -1,0 +1,1 @@
+uid://d4h2q6qj0p6y2

--- a/scenes/entities/crossing/CrossingNpc.tscn
+++ b/scenes/entities/crossing/CrossingNpc.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3 uid="uid://d4h2q6qj0p6y1"]
+
+[ext_resource type="Script" uid="uid://d4h2q6qj0p6y2" path="res://scenes/entities/crossing/CrossingNpc.gd" id="1_crossing"]
+[ext_resource type="Texture2D" uid="uid://81ry5p5m50iv" path="res://assets/sprites/Crowd.png" id="2_ld2lh"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_ld2lh"]
+height = 48.0
+
+[node name="CrossingNpc" type="CharacterBody2D"]
+scale = Vector2(1.5, 1.5)
+collision_layer = 0
+collision_mask = 0
+script = ExtResource("1_crossing")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CapsuleShape2D_ld2lh")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(0, 0.99999666)
+scale = Vector2(1, 1.3)
+texture = ExtResource("2_ld2lh")

--- a/systems/TutorialController.gd
+++ b/systems/TutorialController.gd
@@ -1,5 +1,7 @@
 extends Node
 
+const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/CrossingNpc.tscn")
+
 @onready var world: Node2D = $"../World"
 var player: CharacterBody2D
 @onready var crowd_member = $"../TutorialActors/CrowdMember"
@@ -44,12 +46,34 @@ func on_assignment_completed() -> void:
 		tutorial_complete()
 		return
 	
+	call_deferred("_spawn_crossing_npc")
+
 	if crowd_growth_started:
 		crowd_container.street = street
 		crowd_container.call_deferred("spawn_npc")
 		crowd_container.call_deferred("spawn_npc")
 		
 	generate_assignment()
+
+func _spawn_crossing_npc() -> void:
+	if not world:
+		return
+
+	var pair: Array = world.get_random_store_pair()
+	if pair.size() < 2:
+		return
+
+	var from_store: Node2D = pair[0]
+	var to_store: Node2D = pair[1]
+	if randf() < 0.5:
+		var tmp: Node2D = from_store
+		from_store = to_store
+		to_store = tmp
+
+	var npc: CrossingNpc = CROSSING_NPC_SCN.instantiate() as CrossingNpc
+	world.get_entities_root().add_child(npc)
+	npc.z_index = 3
+	npc.spawn_from_stores(from_store, to_store)
 
 func apply_phase_movement_rules():
 	match current_phase:


### PR DESCRIPTION
Add the crossing NPC entity and spawn it from random store pairs in the main game and tutorial flow.
