### PR TITLE
chore: refresh sprite import metadata

### DIFF
--- a/assets/sprites/Crowd member.png.import
+++ b/assets/sprites/Crowd member.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dbvpfckgqmqmm"
+uid="uid://sdkopqd4scr2"
 path="res://.godot/imported/Crowd member.png-9b4f4854f7d3fb12871aa5ad3a0d55b3.ctex"
 metadata={
 "vram_texture": false

--- a/assets/sprites/Crowd.png.import
+++ b/assets/sprites/Crowd.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://81ry5p5m50iv"
+uid="uid://d2b0ahwl35pss"
 path="res://.godot/imported/Crowd.png-8d877ad2147a09c6a7456e490cd2e8b7.ctex"
 metadata={
 "vram_texture": false

--- a/assets/sprites/Play.png.import
+++ b/assets/sprites/Play.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dhre3w733f56k"
+uid="uid://cvou5bg21d5mw"
 path="res://.godot/imported/Play.png-928d7d5fad7f52e982ef3e4b379a44a1.ctex"
 metadata={
 "vram_texture": false

--- a/assets/sprites/Sprite.png.import
+++ b/assets/sprites/Sprite.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://fa7jwaiveqsx"
+uid="uid://cvnvn7ijv3t5h"
 path="res://.godot/imported/Sprite.png-a901a61a4c444e2afb20edd32cb15947.ctex"
 metadata={
 "vram_texture": false

--- a/assets/sprites/Street.jpg.import
+++ b/assets/sprites/Street.jpg.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://d101h618tlpi3"
+uid="uid://korkshuo1ylj"
 path="res://.godot/imported/Street.jpg-171c694fb473a7838e7b994c1681617f.ctex"
 metadata={
 "vram_texture": false

--- a/assets/sprites/car.png.import
+++ b/assets/sprites/car.png.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cn7e3yhxpsqos"
+uid="uid://b5c6iwvre3u4a"
 path="res://.godot/imported/car.png-c1099737cfd460db4648222bf22ca821.ctex"
 metadata={
 "vram_texture": false


### PR DESCRIPTION
Update texture import UIDs for crowd, player, street, and car assets after asset pipeline refresh.
