### PR TITLE
refactor: centralize crossing npc spawning in CrossingManager

### DIFF
--- a/scenes/app/Game.gd
+++ b/scenes/app/Game.gd
@@ -1,7 +1,5 @@
 extends Node2D
 
-const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/CrossingNpc.tscn")
-
 @onready var world: Node2D  = $World
 @onready var player: Node = world.get_player()
 @onready var crowd_container: CrowdManager = world.get_crowd()
@@ -12,19 +10,21 @@ const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/Cr
 @export var crossing_try_interval: float = 5.0
 @export var crossing_row_memory_size: int = 2
 
-var crossing_spawn_timer: Timer
-var recent_crossing_rows: Array[int] = []
+var crossing_manager: CrossingManager
 
 var stores: Array = []
 var current_assignment_store: Area2D
 
 func _ready() -> void:
 	add_to_group("game")
+	crossing_manager = CrossingManager.new()
+	add_child(crossing_manager)
 
 	init_player()
 	init_stores()
 	init_lanes()
-	_init_crossing_spawn_timer()
+	crossing_manager.configure(world, crossing_spawn_chance, crossing_try_interval, crossing_row_memory_size)
+	crossing_manager.start_auto_spawn()
 
 	generate_assignment()
 
@@ -87,69 +87,3 @@ func init_car(lane: LaneStruct) -> void:
 		return
 	car.lane = lane
 	car.spawn_car(street)
-
-func _init_crossing_spawn_timer() -> void:
-	crossing_spawn_timer = Timer.new()
-	crossing_spawn_timer.one_shot = true
-	crossing_spawn_timer.autostart = false
-	crossing_spawn_timer.timeout.connect(_on_crossing_spawn_timer_timeout)
-	add_child(crossing_spawn_timer)
-	_schedule_next_crossing_try()
-
-func _schedule_next_crossing_try() -> void:
-	crossing_spawn_timer.wait_time = max(crossing_try_interval, 0.1)
-	crossing_spawn_timer.start()
-
-func _on_crossing_spawn_timer_timeout() -> void:
-	try_spawn_crossing_npc()
-	_schedule_next_crossing_try()
-
-func try_spawn_crossing_npc() -> void:
-	if randf() < crossing_spawn_chance:
-		spawn_crossing_npc()
-
-func spawn_crossing_npc() -> void:
-	if not world:
-		return
-
-	var pair: Array = _pick_store_pair_with_memory()
-	if pair.size() < 2:
-		return
-
-	var from_store: Node2D = pair[0]
-	var to_store: Node2D = pair[1]
-	if randf() < 0.5:
-		var tmp: Node2D = from_store
-		from_store = to_store
-		to_store = tmp
-
-	var npc: CrossingNpc = CROSSING_NPC_SCN.instantiate() as CrossingNpc
-	world.get_entities_root().add_child(npc)
-	npc.z_index = 3
-	npc.spawn_from_stores(from_store, to_store)
-
-func _pick_store_pair_with_memory() -> Array:
-	var pairs: Array[Array] = world.get_store_pairs_by_row()
-	if pairs.is_empty():
-		return []
-
-	var candidate_rows: Array[int] = []
-	for i in range(pairs.size()):
-		if not recent_crossing_rows.has(i):
-			candidate_rows.append(i)
-
-	if candidate_rows.is_empty():
-		for i in range(pairs.size()):
-			candidate_rows.append(i)
-
-	var row_idx: int = candidate_rows.pick_random()
-	_remember_crossing_row(row_idx, pairs.size())
-	return pairs[row_idx]
-
-func _remember_crossing_row(row_idx: int, total_rows: int) -> void:
-	if crossing_row_memory_size <= 0:
-		return
-	var clamped_memory: int = clampi(crossing_row_memory_size, 1, max(total_rows - 1, 1))
-	recent_crossing_rows.append(row_idx)
-	while recent_crossing_rows.size() > clamped_memory:
-		recent_crossing_rows.remove_at(0)

--- a/systems/CrossingManager.gd
+++ b/systems/CrossingManager.gd
@@ -1,0 +1,96 @@
+extends Node
+class_name CrossingManager
+
+const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/CrossingNpc.tscn")
+
+var world: Node2D
+var crossing_spawn_chance: float = 0.2
+var crossing_try_interval: float = 5.0
+var crossing_row_memory_size: int = 2
+
+var crossing_spawn_timer: Timer
+var recent_crossing_rows: Array[int] = []
+
+func configure(world_ref: Node2D, spawn_chance: float, try_interval: float, row_memory_size: int) -> void:
+	world = world_ref
+	crossing_spawn_chance = spawn_chance
+	crossing_try_interval = try_interval
+	crossing_row_memory_size = row_memory_size
+	recent_crossing_rows.clear()
+
+func start_auto_spawn() -> void:
+	if not world:
+		return
+	if crossing_spawn_timer == null:
+		crossing_spawn_timer = Timer.new()
+		crossing_spawn_timer.one_shot = true
+		crossing_spawn_timer.autostart = false
+		crossing_spawn_timer.timeout.connect(_on_crossing_spawn_timer_timeout)
+		add_child(crossing_spawn_timer)
+	_schedule_next_crossing_try()
+
+func stop_auto_spawn() -> void:
+	if crossing_spawn_timer:
+		crossing_spawn_timer.stop()
+
+func try_spawn_with_chance() -> CrossingNpc:
+	if randf() >= crossing_spawn_chance:
+		return null
+	return spawn_crossing_npc()
+
+func spawn_crossing_npc(from_store: Node2D = null, to_store: Node2D = null) -> CrossingNpc:
+	if not world:
+		return null
+
+	if from_store == null or to_store == null:
+		var pair: Array = _pick_store_pair_with_memory()
+		if pair.size() < 2:
+			return null
+		from_store = pair[0]
+		to_store = pair[1]
+		if randf() < 0.5:
+			var tmp: Node2D = from_store
+			from_store = to_store
+			to_store = tmp
+
+	var npc: CrossingNpc = CROSSING_NPC_SCN.instantiate() as CrossingNpc
+	world.get_entities_root().add_child(npc)
+	npc.z_index = 3
+	npc.spawn_from_stores(from_store, to_store)
+	return npc
+
+func _on_crossing_spawn_timer_timeout() -> void:
+	try_spawn_with_chance()
+	_schedule_next_crossing_try()
+
+func _schedule_next_crossing_try() -> void:
+	if crossing_spawn_timer == null:
+		return
+	crossing_spawn_timer.wait_time = max(crossing_try_interval, 0.1)
+	crossing_spawn_timer.start()
+
+func _pick_store_pair_with_memory() -> Array:
+	var pairs: Array[Array] = world.get_store_pairs_by_row()
+	if pairs.is_empty():
+		return []
+
+	var candidate_rows: Array[int] = []
+	for i in range(pairs.size()):
+		if not recent_crossing_rows.has(i):
+			candidate_rows.append(i)
+
+	if candidate_rows.is_empty():
+		for i in range(pairs.size()):
+			candidate_rows.append(i)
+
+	var row_idx: int = candidate_rows.pick_random()
+	_remember_crossing_row(row_idx, pairs.size())
+	return pairs[row_idx]
+
+func _remember_crossing_row(row_idx: int, total_rows: int) -> void:
+	if crossing_row_memory_size <= 0:
+		return
+	var clamped_memory: int = clampi(crossing_row_memory_size, 1, max(total_rows - 1, 1))
+	recent_crossing_rows.append(row_idx)
+	while recent_crossing_rows.size() > clamped_memory:
+		recent_crossing_rows.remove_at(0)

--- a/systems/CrossingManager.gd.uid
+++ b/systems/CrossingManager.gd.uid
@@ -1,0 +1,1 @@
+uid://b8c62jjoopqge

--- a/systems/TutorialController.gd
+++ b/systems/TutorialController.gd
@@ -1,6 +1,12 @@
 extends Node
 
-const CROSSING_NPC_SCN: PackedScene = preload("res://scenes/entities/crossing/CrossingNpc.tscn")
+const SCRIPTED_EVENT_STORE_ID: int = 1
+const SCRIPTED_EVENT_FROM_STORE_ID: int = 2
+const SCRIPTED_EVENT_CAR_LANE_INDEX: int = 2
+const SCRIPTED_EVENT_BRAKE_DELAY_SEC: float = 1.0
+const TUTORIAL_CROSSING_SPAWN_CHANCE: float = 0.2
+const TUTORIAL_CROSSING_TRY_INTERVAL: float = 5.0
+const TUTORIAL_CROSSING_MEMORY_SIZE: int = 2
 
 @onready var world: Node2D = $"../World"
 var player: CharacterBody2D
@@ -19,6 +25,10 @@ var stores: Array
 var store_map := {}
 var first_push := false
 var crowd_growth_started := false
+var scripted_tutorial_event_done: bool = false
+var scripted_tutorial_car_original_speed: float = 0.0
+var scripted_crossing_active: bool = false
+var crossing_manager: CrossingManager
 
 func _ready() -> void:
 	await get_tree().process_frame
@@ -26,6 +36,9 @@ func _ready() -> void:
 	street = world.get_street()
 	crowd_container = world.get_crowd()
 	hint.set_target(player)
+	crossing_manager = CrossingManager.new()
+	add_child(crossing_manager)
+	crossing_manager.configure(world, TUTORIAL_CROSSING_SPAWN_CHANCE, TUTORIAL_CROSSING_TRY_INTERVAL, TUTORIAL_CROSSING_MEMORY_SIZE)
 	if player.has_signal("boost_used"):
 		player.boost_used.connect(_on_player_boost_used)
 
@@ -43,6 +56,8 @@ func generate_assignment():
 	apply_phase_movement_rules()
 	if currentStoreNum == 0:
 		hint.show_hint()
+	if currentStoreNum == SCRIPTED_EVENT_STORE_ID and not scripted_tutorial_event_done:
+		call_deferred("_start_scripted_tutorial_crossing_event")
 
 func on_assignment_completed() -> void:
 	current_phase += 1
@@ -50,7 +65,9 @@ func on_assignment_completed() -> void:
 		tutorial_complete()
 		return
 
-	call_deferred("_spawn_crossing_npc")
+	var next_store_num: int = assignment_order[current_phase]
+	if next_store_num != SCRIPTED_EVENT_STORE_ID:
+		call_deferred("_spawn_crossing_npc")
 
 	if crowd_growth_started:
 		crowd_container.street = street
@@ -102,3 +119,75 @@ func _on_crowd_member_pushed():
 
 func _on_player_boost_used() -> void:
 	hint.hide_hint()
+
+func _spawn_crossing_npc() -> void:
+	if crossing_manager == null:
+		return
+	crossing_manager.spawn_crossing_npc()
+
+func _start_scripted_tutorial_crossing_event() -> void:
+	if scripted_tutorial_event_done:
+		return
+	if crossing_manager == null:
+		return
+	scripted_tutorial_event_done = true
+
+	var from_store: Node2D = store_map.get(SCRIPTED_EVENT_FROM_STORE_ID)
+	var to_store: Node2D = world.get_paired_store(SCRIPTED_EVENT_FROM_STORE_ID)
+	if from_store == null or to_store == null:
+		return
+
+	var npc: CrossingNpc = crossing_manager.spawn_crossing_npc(from_store, to_store)
+	if npc == null:
+		return
+	npc.crossing_started.connect(_on_scripted_crossing_started)
+	npc.crossing_ended.connect(_on_scripted_crossing_ended)
+
+	_prepare_scripted_tutorial_car()
+
+func _prepare_scripted_tutorial_car() -> void:
+	var car: Node = world.get_car()
+	if car == null:
+		return
+
+	if car is Node2D:
+		(car as Node2D).visible = true
+	car.set_process(true)
+	car.set_physics_process(true)
+
+	var hitbox: Area2D = car.get_node_or_null("Hitbox")
+	if hitbox:
+		# Keep tutorial focused on the braking behavior instead of punishing collisions.
+		hitbox.monitoring = false
+
+	if SCRIPTED_EVENT_CAR_LANE_INDEX < 0 or SCRIPTED_EVENT_CAR_LANE_INDEX >= LaneManager.LanesArray.size():
+		return
+	var lane: LaneStruct = LaneManager.LanesArray[SCRIPTED_EVENT_CAR_LANE_INDEX]
+	if lane.type != LaneManager.LaneType.CAR:
+		return
+	var spawn_top: bool = lane.direction.y > 0.0
+	var spawn_pos: Vector2 = street.get_spawn_line(spawn_top)
+	spawn_pos.x = lane.center.x
+	car.set("global_position", spawn_pos)
+
+	car.set("street", street)
+	car.set("direction", lane.direction)
+	scripted_tutorial_car_original_speed = car.get("target_speed")
+	car.set("current_speed", scripted_tutorial_car_original_speed)
+
+func _on_scripted_crossing_started(_row_y: float) -> void:
+	scripted_crossing_active = true
+	await get_tree().create_timer(SCRIPTED_EVENT_BRAKE_DELAY_SEC).timeout
+	if not scripted_crossing_active:
+		return
+	var car: Node = world.get_car()
+	if car == null:
+		return
+	car.set("target_speed", 0.0)
+
+func _on_scripted_crossing_ended(_row_y: float) -> void:
+	scripted_crossing_active = false
+	var car: Node = world.get_car()
+	if car == null:
+		return
+	car.set("target_speed", scripted_tutorial_car_original_speed)


### PR DESCRIPTION
Extract crossing spawn logic into a reusable manager and wire both Game and Tutorial to use it so crossing behavior is shared from one place