### PR TITLE
fix: keep crossing NPC animation playing per movement direction

### DIFF
--- a/scenes/entities/crossing/CrossingNpc.gd
+++ b/scenes/entities/crossing/CrossingNpc.gd
@@ -6,7 +6,6 @@ signal crossing_ended(row_y: float)
 
 @export var speed: float = 180.0
 
-var time := 0.0
 var target_x: float = 0.0
 var row_y: float = 0.0
 var _active: bool = false
@@ -17,16 +16,6 @@ func _ready() -> void:
 func is_crossing_active() -> bool:
 	return _active
 	
-func _process(delta):
-	time += delta
-	
-	# Lean forward (depends on direction)
-	var dir : float = sign(velocity.x) # -1 left, +1 right
-	rotation = dir * 0.15
-	
-	# Vertical bob (walking feel)
-	var bob = sin(time * 10.0) * 0.05
-	position.y += bob
 
 func spawn_from_stores(left_store: Node2D, right_store: Node2D) -> void:
 	if not is_in_group("crossing_npcs"):
@@ -38,6 +27,8 @@ func spawn_from_stores(left_store: Node2D, right_store: Node2D) -> void:
 	var dir_x: float = sign(target_x - global_position.x)
 	if dir_x == 0.0:
 		dir_x = 1.0
+	_update_anim_for_direction(dir_x)
+		
 	_active = true
 	emit_signal("crossing_started", row_y)
 
@@ -48,6 +39,10 @@ func _physics_process(_delta: float) -> void:
 	global_position.y = row_y
 
 	var dir_x: float = sign(target_x - global_position.x)
+	if dir_x == 0.0:
+		dir_x = 1.0
+	_update_anim_for_direction(dir_x)
+		
 	velocity = Vector2(dir_x * speed, 0.0)
 	move_and_slide()
 
@@ -55,3 +50,14 @@ func _physics_process(_delta: float) -> void:
 	if reached:
 		emit_signal("crossing_ended", row_y)
 		queue_free()
+
+func play_anim(name: StringName) -> void:
+	var sprite: AnimatedSprite2D = $AnimatedSprite2D
+	if sprite.animation != name:
+		sprite.play(name)
+	elif not sprite.is_playing():
+		# Ensure the current animation resumes if it got stopped.
+		sprite.play()
+
+func _update_anim_for_direction(dir_x: float) -> void:
+	play_anim("crossing_right" if dir_x > 0.0 else "crossing_left")


### PR DESCRIPTION
Update crossing NPC direction animation selection so left/right playback matches movement and resumes correctly if playback was stopped, preventing static moonwalk behavior.
