### PR TITLE
feat: use manual lane patterns and spawn cars across car lanes

### DIFF
--- a/scenes/app/Game.gd
+++ b/scenes/app/Game.gd
@@ -5,6 +5,8 @@ extends Node2D
 @onready var crowd_container: CrowdManager = world.get_crowd()
 @onready var car: Node2D = world.get_car()
 
+const CAR_SCENE: PackedScene = preload("res://scenes/entities/car/Car.tscn")
+
 @export var crossing_spawn_chance: float = 0.2
 @export var crossing_try_interval: float = 5.0
 @export var crossing_row_memory_size: int = 2
@@ -82,28 +84,24 @@ func init_lanes():
 				car_lanes.append(lane)
 	
 	if not car_lanes.is_empty():
-		init_car(_get_central_car_lane(car_lanes))
+		init_cars(car_lanes)
 
-func init_car(lane: LaneStruct) -> void:
-	if not car:
+func init_cars(car_lanes: Array[LaneStruct]) -> void:
+	if not car or car_lanes.is_empty():
 		return
-	car.lane = lane
+
+	# Reuse the scene car for the first lane, then instantiate one per remaining car lane.
+	car.lane = car_lanes[0]
 	car.spawn_car()
+
+	var parent_node: Node = car.get_parent()
+	for i in range(1, car_lanes.size()):
+		var extra_car: Node2D = CAR_SCENE.instantiate()
+		extra_car.lane = car_lanes[i]
+		parent_node.add_child(extra_car)
+		extra_car.spawn_car()
 
 func init_tilemap():
 	LaneManager.set_tilemap(world.get_tilemap())
 	LaneManager.generate_lanes()
 
-func _get_central_car_lane(car_lanes: Array[LaneStruct]) -> LaneStruct:
-	var center_x: float = get_viewport().get_visible_rect().size.x * 0.5
-	var best: LaneStruct = car_lanes[0]
-	var best_width: int = best.line.size()
-	var best_dist: float = absf(best.center.x - center_x)
-	for lane: LaneStruct in car_lanes:
-		var lane_width: int = lane.line.size()
-		var dist: float = absf(lane.center.x - center_x)
-		if lane_width > best_width or (lane_width == best_width and dist < best_dist):
-			best = lane
-			best_width = lane_width
-			best_dist = dist
-	return best

--- a/systems/LaneManager.gd
+++ b/systems/LaneManager.gd
@@ -9,21 +9,28 @@ enum LaneType {
 
 const TILE_SIZE_PX: float = 32.0
 const CAR_LANE_WIDTH_TILES: int = 3
+const USE_MANUAL_LANE_LAYOUT: bool = true
 
 var LanesArray = []
 var tilemap: TileMapLayer
 
+func populate_lanes_array() -> void:
+	LanesArray.clear()
 
-#func populate_lanes_array():
-	#LanesArray.clear()
-	#
-	#LanesArray.append(LaneStruct.new(LaneType.CAR, [1], Vector2.DOWN, Vector2(lane_x(0), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CROWD_MEMBER, [1, 2, 3], Vector2.DOWN, Vector2(lane_x(1), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CAR, [1], Vector2.UP, Vector2(lane_x(2), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CROWD_MEMBER, [0], Vector2.UP, Vector2(lane_x(3), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CAR, [0], Vector2.DOWN, Vector2(lane_x(4), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CROWD_MEMBER, [1, 3, 1], Vector2.UP, Vector2(lane_x(5), 0)))
-	#LanesArray.append(LaneStruct.new(LaneType.CAR, [0], Vector2.UP, Vector2(lane_x(6), 0)))
+	var center_y: int = _get_center_y()
+	var car_line := _manual_car_line()
+	var columns_by_type := _collect_columns()
+	var car_groups: Array = _group_columns(columns_by_type.get("driveable", []))
+	var crowd_groups: Array = _group_columns(columns_by_type.get("walkable", []))
+
+	# Keep manual direction/spawn pattern, but use natural tilemap centers from grouped columns.
+	_append_manual_lane(LaneType.EMPTY, car_line, Vector2.DOWN, car_groups, 0, center_y)
+	_append_manual_lane(LaneType.CROWD_MEMBER, [1, 2, 3], Vector2.DOWN, crowd_groups, 0, center_y)
+	_append_manual_lane(LaneType.CAR, car_line, Vector2.UP, car_groups, 1, center_y)
+	_append_manual_lane(LaneType.CROWD_MEMBER, [0], Vector2.UP, crowd_groups, 1, center_y)
+	_append_manual_lane(LaneType.CAR, car_line, Vector2.DOWN, car_groups, 2, center_y)
+	_append_manual_lane(LaneType.CROWD_MEMBER, [1, 3, 1], Vector2.UP, crowd_groups, 2, center_y)
+	_append_manual_lane(LaneType.CAR, car_line, Vector2.UP, car_groups, 3, center_y)
 
 # ----- tileset
 
@@ -72,6 +79,10 @@ func get_nearest_lane_by_type(world_x: float, lane_type: LaneType) -> LaneStruct
 # ----------------------------
 
 func generate_lanes():
+	if USE_MANUAL_LANE_LAYOUT:
+		populate_lanes_array()
+		return
+
 	LanesArray.clear()
 
 	var columns_by_type = _collect_columns()
@@ -192,4 +203,18 @@ func _get_spawn_pattern(lane_type: LaneType, index: int) -> Array:
 func _get_center_y() -> int:
 	var used_ = tilemap.get_used_rect()
 	return used_.position.y + used_.size.y / 2
-	
+
+func _manual_car_line() -> Array:
+	var line: Array = []
+	for i in range(CAR_LANE_WIDTH_TILES):
+		line.append(i)
+	return line
+
+func _append_manual_lane(lane_type: LaneType, line: Array, dir: Vector2, groups: Array, group_index: int, center_y: int) -> void:
+	if groups.is_empty():
+		return
+	var idx: int = mini(group_index, groups.size() - 1)
+	var lane_cols: Array = groups[idx]
+	var center_x: int = lane_cols[lane_cols.size() / 2]
+	var world_pos: Vector2 = tilemap.map_to_local(Vector2i(center_x, center_y))
+	LanesArray.append(LaneStruct.new(lane_type, line, dir, world_pos))


### PR DESCRIPTION
Restore manual lane direction/spawn patterns while keeping tilemap-derived lane centers, and spawn one car per configured CAR lane instead of forcing a single central lane