### PR TITLE
feat: tune store shader mask colors and material defaults

### DIFF
--- a/scenes/world/Store.gdshader
+++ b/scenes/world/Store.gdshader
@@ -1,30 +1,28 @@
 shader_type canvas_item;
 
-uniform sampler2D mask_texture;
+uniform sampler2D mask_texture : filter_nearest;
 
 uniform vec4 roof_color : source_color;
-uniform vec4 wall_color : source_color;
+uniform vec4 wall_color : source_color;   // parede + chaminé
 uniform vec4 door_color : source_color;
 
-uniform vec3 baseline = vec3(0.5, 0.5, 0.5);
-
 void fragment() {
-	vec3 og_roof_color = vec3(0,0,0);
-    vec4 base = texture(TEXTURE, UV);
-    vec3 mask = texture(mask_texture, UV).rgb;
+    vec4 tex = texture(TEXTURE, UV);
+    vec4 mask = texture(mask_texture, UV);
+	
+    vec3 final_color = tex.rgb;
 
-    vec3 detail = base.rgb - baseline;
-    vec3 result = base.rgb;
+   float intensity = dot(tex.rgb, vec3(0.299, 0.587, 0.114));
 
-    if (mask.r > 0.9) {
-        result = roof_color.rgb - og_roof_color + detail;
-    }
-    else if (mask.g > 0.9) {
-        result = wall_color.rgb + detail;
-    }
-    else if (mask.b > 0.9) {
-        result = door_color.rgb + detail;
-    }
-
-    COLOR = vec4(result, base.a);
+	if (mask.r > mask.g && mask.r > mask.b) {
+	    final_color = roof_color.rgb * intensity;
+	} else if (mask.g > mask.r && mask.g > mask.b) {
+	    final_color = wall_color.rgb * intensity;
+	} else if (mask.b > mask.r && mask.b > mask.g) {
+	    final_color = door_color.rgb * intensity;
+	}
+	
+	float edge = step(0.5, tex.a);
+	vec3 result = mix(tex.rgb, final_color, edge);
+    COLOR = vec4(final_color, tex.a);
 }

--- a/scenes/world/Store.tscn
+++ b/scenes/world/Store.tscn
@@ -12,12 +12,12 @@ size = Vector2(103, 120)
 size = Vector2(70, 100)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_50jip"]
+resource_local_to_scene = true
 shader = ExtResource("2_nm48x")
 shader_parameter/mask_texture = ExtResource("3_50jip")
-shader_parameter/roof_color = Color(0, 0, 0, 1)
-shader_parameter/wall_color = Color(0, 0, 0, 1)
-shader_parameter/door_color = Color(0, 0, 0, 1)
-shader_parameter/baseline = Vector3(0, 0, 0)
+shader_parameter/roof_color = Color(0.78431374, 0.78431374, 0.84705883, 1)
+shader_parameter/wall_color = Color(0.38464656, 2.851747e-06, 0.2012113, 1)
+shader_parameter/door_color = Color(0.9713355, 0.9713355, 0.9713355, 1)
 
 [node name="Store" type="Area2D" groups=["stores"]]
 collision_mask = 2


### PR DESCRIPTION
Adjust the store shader to use mask-dominant color regions with luminance-based tinting, and update scene material parameters so stores render with the intended palette by default.