### PR TITLE
feat: align world boundaries to camera limits

### DIFF
--- a/scenes/app/World.tscn
+++ b/scenes/app/World.tscn
@@ -1,7 +1,6 @@
 [gd_scene load_steps=116 format=4 uid="uid://c7mt612o4cb6b"]
 
 [ext_resource type="Script" uid="uid://cuats8koek3qw" path="res://scenes/app/World.gd" id="1_jdyhp"]
-[ext_resource type="PackedScene" uid="uid://cescocnbuiapm" path="res://scenes/world/WallBound.tscn" id="2_jdyhp"]
 [ext_resource type="PackedScene" uid="uid://bpsq6auy0kf62" path="res://scenes/world/Fence.tscn" id="3_4t2ey"]
 [ext_resource type="Texture2D" uid="uid://b4yqhdvnetsub" path="res://assets/sprites/street/ME_Singles_City_Terrains_32x32_Asphalt_1_Variation_8.png" id="3_bkdrh"]
 [ext_resource type="Texture2D" uid="uid://buj0av560euyw" path="res://assets/sprites/street/ME_Singles_City_Terrains_32x32_Asphalt_1_Variation_15.png" id="4_3vt6v"]
@@ -508,7 +507,10 @@ sources/57 = SubResource("TileSetAtlasSource_ptlxu")
 sources/58 = SubResource("TileSetAtlasSource_ph0el")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_q24mn"]
-size = Vector2(455, 20)
+size = Vector2(1152, 20)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_vert"]
+size = Vector2(20, 768)
 
 [node name="World" type="Node2D"]
 script = ExtResource("1_jdyhp")
@@ -534,37 +536,36 @@ tile_set = SubResource("TileSet_4222n")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 anchor_mode = 0
+limit_left = 0
+limit_top = 0
+limit_right = 1152
+limit_bottom = 768
 
 [node name="Boundaries" type="Node2D" parent="."]
 
-[node name="WallBottom" parent="Boundaries" instance=ExtResource("2_jdyhp")]
-visible = false
-
 [node name="WallTop" type="StaticBody2D" parent="Boundaries"]
-visible = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Boundaries/WallTop"]
-visible = false
-position = Vector2(641, 6)
-scale = Vector2(2.8, 0.5)
+position = Vector2(576, -10)
+shape = SubResource("RectangleShape2D_q24mn")
+
+[node name="WallBottom" type="StaticBody2D" parent="Boundaries"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Boundaries/WallBottom"]
+position = Vector2(576, 778)
 shape = SubResource("RectangleShape2D_q24mn")
 
 [node name="WallLeft" type="StaticBody2D" parent="Boundaries"]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Boundaries/WallLeft"]
-position = Vector2(-5, 359)
-rotation = 1.5707964
-scale = Vector2(1.6, 0.5)
-shape = SubResource("RectangleShape2D_q24mn")
+position = Vector2(-10, 384)
+shape = SubResource("RectangleShape2D_vert")
 
 [node name="WallRight" type="StaticBody2D" parent="Boundaries"]
-position = Vector2(-47, 73)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Boundaries/WallRight"]
-position = Vector2(1198, 287.00003)
-rotation = 1.5707964
-scale = Vector2(1.6, 0.5)
-shape = SubResource("RectangleShape2D_q24mn")
+position = Vector2(1162, 384)
+shape = SubResource("RectangleShape2D_vert")
 
 [node name="Fences" type="Node2D" parent="Boundaries"]
 visible = false

--- a/scenes/world/WallBound.tscn
+++ b/scenes/world/WallBound.tscn
@@ -1,11 +1,10 @@
 [gd_scene load_steps=2 format=3 uid="uid://cescocnbuiapm"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_q24mn"]
-size = Vector2(455, 20)
+size = Vector2(1152, 20)
 
 [node name="WallBottom" type="StaticBody2D"]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(639, 717)
-scale = Vector2(2.8, 0.5)
+position = Vector2(576, 717)
 shape = SubResource("RectangleShape2D_q24mn")


### PR DESCRIPTION
Set explicit camera limits for the resized world and normalize boundary collider dimensions/positions so top, bottom, left, and right walls match the playable viewport.