### PR TITLE
fix(world): add truck collider and avoid first crossing row

### DIFF
--- a/scenes/entities/crowd/CrowdMember.tscn
+++ b/scenes/entities/crowd/CrowdMember.tscn
@@ -11,7 +11,7 @@ height = 48.0
 [node name="CrowdMember" type="CharacterBody2D" groups=["crowd"]]
 z_index = 2
 collision_layer = 4
-collision_mask = 0
+collision_mask = 1
 script = ExtResource("1_g3vus")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/scenes/entities/delivery truck/DeliveryTruck.tscn
+++ b/scenes/entities/delivery truck/DeliveryTruck.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=3 uid="uid://b8i6nf5av6xyi"]
+[gd_scene load_steps=27 format=3 uid="uid://b8i6nf5av6xyi"]
 
 [ext_resource type="Texture2D" uid="uid://lxhtapf3icv2" path="res://assets/sprites/delivery truck/Delivery_Truck_32x32.png" id="1_jl8hp"]
 [ext_resource type="Texture2D" uid="uid://cng06n7dm8d8u" path="res://assets/sprites/delivery truck/Delivery_Truck_Door_32x32.png" id="2_qv7li"]
@@ -160,6 +160,9 @@ animations = [{
 "speed": 5.0
 }]
 
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qv7li"]
+size = Vector2(74, 154)
+
 [node name="Delivery Truck" type="Node2D"]
 script = ExtResource("3_5wsk7")
 
@@ -174,3 +177,13 @@ position = Vector2(9.499999, 70)
 scale = Vector2(0.8046875, 0.64583325)
 sprite_frames = SubResource("SpriteFrames_h1oym")
 animation = &"door_open"
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+collision_layer = 1
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+show_behind_parent = true
+top_level = true
+position = Vector2(12, 24)
+shape = SubResource("RectangleShape2D_qv7li")

--- a/systems/CrossingManager.gd
+++ b/systems/CrossingManager.gd
@@ -98,12 +98,19 @@ func _pick_store_pair_with_memory() -> Array:
 
 	var candidate_rows: Array[int] = []
 	for i in range(pairs.size()):
+		if i == 0:
+			continue
 		if not recent_crossing_rows.has(i):
 			candidate_rows.append(i)
 
 	if candidate_rows.is_empty():
 		for i in range(pairs.size()):
+			if i == 0:
+				continue
 			candidate_rows.append(i)
+
+	if candidate_rows.is_empty():
+		return []
 
 	var row_idx: int = candidate_rows.pick_random()
 	_remember_crossing_row(row_idx, pairs.size())


### PR DESCRIPTION
Make the delivery truck block the player and crowd via a StaticBody2D on the World layer, and skip row 0 when selecting crossing store pairs.