### PR TITLE
fix(audio): route mute through soundcontroller

### DIFF
--- a/scenes/ui/MuteHudIcon.gd
+++ b/scenes/ui/MuteHudIcon.gd
@@ -1,7 +1,5 @@
 extends HudAnimatedIconButton
 
-const MASTER_BUS := "Master"
-
 @export var idle_texture_muted: Texture2D
 
 @onready var overlay_unmute: AnimatedSprite2D = $OverlayUnmute
@@ -13,15 +11,14 @@ func _ready() -> void:
 	overlay_unmute.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	overlay_unmute.visible = false
 	interacted.connect(_on_interacted)
+	if SoundController and SoundController.has_signal("muted_changed"):
+		SoundController.muted_changed.connect(func(_m: bool) -> void: _refresh_underlay_texture())
 	_refresh_underlay_texture()
 
 
 func _on_interacted() -> void:
-	var idx := AudioServer.get_bus_index(MASTER_BUS)
-	if idx < 0:
-		return
-	AudioServer.set_bus_mute(idx, not AudioServer.is_bus_mute(idx))
-	_refresh_underlay_texture()
+	if SoundController and SoundController.has_method("toggle_mute"):
+		SoundController.toggle_mute()
 
 
 func _refresh_underlay_texture() -> void:
@@ -29,8 +26,9 @@ func _refresh_underlay_texture() -> void:
 		return
 	if idle_texture == null and idle_texture_muted == null:
 		return
-	var idx := AudioServer.get_bus_index(MASTER_BUS)
-	var muted := idx >= 0 and AudioServer.is_bus_mute(idx)
+	var muted := false
+	if SoundController and SoundController.has_method("is_muted"):
+		muted = SoundController.is_muted()
 	if muted:
 		idle_rect.texture = idle_texture_muted if idle_texture_muted else idle_texture
 	else:
@@ -39,8 +37,9 @@ func _refresh_underlay_texture() -> void:
 
 
 func _press_down_override() -> bool:
-	var idx := AudioServer.get_bus_index(MASTER_BUS)
-	var muted := idx >= 0 and AudioServer.is_bus_mute(idx)
+	var muted := false
+	if SoundController and SoundController.has_method("is_muted"):
+		muted = SoundController.is_muted()
 	sprite.visible = false
 	overlay_unmute.visible = false
 	if muted:
@@ -76,8 +75,9 @@ func _center_sprite() -> void:
 
 
 func _reference_size_for_overlay() -> Vector2:
-	var idx := AudioServer.get_bus_index(MASTER_BUS)
-	var muted := idx >= 0 and AudioServer.is_bus_mute(idx)
+	var muted := false
+	if SoundController and SoundController.has_method("is_muted"):
+		muted = SoundController.is_muted()
 	if muted:
 		if idle_texture_muted:
 			return idle_texture_muted.get_size()

--- a/systems/SoundController.gd
+++ b/systems/SoundController.gd
@@ -1,11 +1,16 @@
 extends Node
 
+signal muted_changed(is_muted: bool)
+
 const BELL_STREAM_PATH := "res://assets/sounds/BellRing.mp3"
 const CAR_CRASH_1_STREAM_PATH := "res://assets/sounds/CarCrash1.mp3"
 const CAR_CRASH_2_STREAM_PATH := "res://assets/sounds/CarCrash2.mp3"
 const BACKGROUND_MUSIC_STREAM_PATH := "res://assets/sounds/Background.mp3"
 const KEY_PRESS_STREAM_PATH := "res://assets/sounds/KeyPressed.mp3"
 const DOOR_SOUNDS_STREAM_PATH := "res://assets/sounds/DoorSounds.mp3"
+
+const MASTER_BUS := "Master"
+var _muted: bool = false
 
 var bell_stream: AudioStream
 var car_crash_stream_1: AudioStream
@@ -32,6 +37,8 @@ var key_press_player: AudioStreamPlayer
 var door_player: AudioStreamPlayer
 
 func _ready() -> void:
+	_sync_mute_from_audio_server()
+
 	bell_stream = _try_load_stream(BELL_STREAM_PATH)
 	car_crash_stream_1 = _try_load_stream(CAR_CRASH_1_STREAM_PATH)
 	car_crash_stream_2 = _try_load_stream(CAR_CRASH_2_STREAM_PATH)
@@ -69,6 +76,26 @@ func _ready() -> void:
 	add_child(door_player)
 
 	_play_background_music()
+
+func is_muted() -> bool:
+	return _muted
+
+func set_muted(value: bool) -> void:
+	value = bool(value)
+	var idx := AudioServer.get_bus_index(MASTER_BUS)
+	if idx >= 0:
+		AudioServer.set_bus_mute(idx, value)
+	var changed := _muted != value
+	_muted = value
+	if changed:
+		muted_changed.emit(_muted)
+
+func toggle_mute() -> void:
+	set_muted(not _muted)
+
+func _sync_mute_from_audio_server() -> void:
+	var idx := AudioServer.get_bus_index(MASTER_BUS)
+	_muted = idx >= 0 and AudioServer.is_bus_mute(idx)
 
 func _play_background_music() -> void:
 	if not background_music_stream:


### PR DESCRIPTION
Make SoundController own global mute state (Master bus) and expose toggle/set APIs; update the mute HUD button to call the autoload and sync via muted_changed.